### PR TITLE
Enable LinkGenerator for Registries, fix missing Lang keys

### DIFF
--- a/examples/runConfig.json
+++ b/examples/runConfig.json
@@ -2,7 +2,7 @@
   "packName": "Embers",
   "packId": "embers_groovyscript",
   "version": "1.0.0",
-  "debug": false,
+  "debug": true,
   "classes": {
     "preInit": []
   },

--- a/src/main/java/teamroots/embers/compat/groovyscript/Alchemy.java
+++ b/src/main/java/teamroots/embers/compat/groovyscript/Alchemy.java
@@ -52,7 +52,7 @@ public class Alchemy extends VirtualizedRegistry<AlchemyRecipe> {
         return false;
     }
 
-    @MethodDescription(type = MethodDescription.Type.REMOVAL, example = @Example("item('minecraft:wool')"))
+    @MethodDescription(type = MethodDescription.Type.REMOVAL, description = "groovyscript.wiki.embers.alchemy.removebycenter", example = @Example("item('minecraft:wool')"))
     public boolean removeByCenter(IIngredient input) {
         return RecipeRegistry.alchemyRecipes.removeIf(r -> {
             if (Arrays.stream(r.getCenter().getMatchingStacks()).anyMatch(input)) {
@@ -74,14 +74,14 @@ public class Alchemy extends VirtualizedRegistry<AlchemyRecipe> {
         });
     }
 
-    @MethodDescription(type = MethodDescription.Type.REMOVAL, example = @Example("'copper'"))
+    @MethodDescription(type = MethodDescription.Type.REMOVAL, description = "groovyscript.wiki.embers.alchemy.removeaspect", example = @Example("'copper'"))
     public boolean removeAspect(String aspect) {
         if (!AlchemyUtil.hasAspect(aspect)) return false;
         AlchemyUtil.removeAspect(aspect);
         return true;
     }
 
-    @MethodDescription(type = MethodDescription.Type.ADDITION, example = {@Example("'copper',item('minecraft:gold_ingot')"), @Example("'glass',item('minecraft:glass')")})
+    @MethodDescription(type = MethodDescription.Type.ADDITION, description = "groovyscript.wiki.embers.alchemy.addaspect", example = {@Example("'copper',item('minecraft:gold_ingot')"), @Example("'glass',item('minecraft:glass')")})
     public boolean addAspect(String aspect, IIngredient item) {
         if (getAspect(item) != null) return false;
         AlchemyUtil.registerAspect(aspect, item.toMcIngredient());
@@ -107,9 +107,10 @@ public class Alchemy extends VirtualizedRegistry<AlchemyRecipe> {
     @Property(property = "input", valid = {@Comp(value = "1", type = Comp.Type.GTE), @Comp(value = "5", type = Comp.Type.LTE)})
     @Property(property = "output", valid = @Comp("1"))
     public static class RecipeBuilder extends AbstractRecipeBuilder<AlchemyRecipe> {
+        @Property(valid = @Comp(value = "empty", type = Comp.Type.NOT))
         private final AspectList.AspectRangeList aspects = new AspectList.AspectRangeList();
 
-        @RecipeBuilderMethodDescription
+        @RecipeBuilderMethodDescription(field = "aspects")
         public RecipeBuilder setAspect(String aspect, int min, int max) {
             this.aspects.setRange(aspect, min, max);
             return this;

--- a/src/main/java/teamroots/embers/compat/groovyscript/Alchemy.java
+++ b/src/main/java/teamroots/embers/compat/groovyscript/Alchemy.java
@@ -11,6 +11,7 @@ import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import com.google.common.collect.Lists;
 import groovyjarjarantlr4.v4.runtime.misc.Nullable;
 import net.minecraft.item.crafting.Ingredient;
+import teamroots.embers.Embers;
 import teamroots.embers.api.alchemy.AspectList;
 import teamroots.embers.recipe.AlchemyRecipe;
 import teamroots.embers.recipe.RecipeRegistry;
@@ -19,7 +20,7 @@ import teamroots.embers.util.AlchemyUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-@RegistryDescription
+@RegistryDescription(linkGenerator = Embers.MODID)
 public class Alchemy extends VirtualizedRegistry<AlchemyRecipe> {
     @RecipeBuilderDescription(example = {
             @Example(".input(item('minecraft:clay'),item('minecraft:clay'),item('minecraft:clay'),item('minecraft:clay')).output(item('minecraft:gravel')).setAspect('dawnstone', 2, 17).setAspect('glass', 1, 8)"),

--- a/src/main/java/teamroots/embers/compat/groovyscript/HeatCoil.java
+++ b/src/main/java/teamroots/embers/compat/groovyscript/HeatCoil.java
@@ -8,12 +8,13 @@ import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import groovyjarjarantlr4.v4.runtime.misc.Nullable;
+import teamroots.embers.Embers;
 import teamroots.embers.recipe.HeatCoilRecipe;
 import teamroots.embers.recipe.RecipeRegistry;
 
 import java.util.Arrays;
 
-@RegistryDescription
+@RegistryDescription(linkGenerator = Embers.MODID)
 public class HeatCoil extends VirtualizedRegistry<HeatCoilRecipe> {
     @RecipeBuilderDescription(example = {
             @Example(".input(item('minecraft:clay')).output(item('minecraft:gravel'))"),

--- a/src/main/java/teamroots/embers/compat/groovyscript/Melter.java
+++ b/src/main/java/teamroots/embers/compat/groovyscript/Melter.java
@@ -8,12 +8,13 @@ import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import org.jetbrains.annotations.Nullable;
+import teamroots.embers.Embers;
 import teamroots.embers.recipe.ItemMeltingRecipe;
 import teamroots.embers.recipe.RecipeRegistry;
 
 import java.util.Arrays;
 
-@RegistryDescription
+@RegistryDescription(linkGenerator = Embers.MODID)
 public class Melter extends VirtualizedRegistry<ItemMeltingRecipe> {
 
     @RecipeBuilderDescription(example = {

--- a/src/main/java/teamroots/embers/compat/groovyscript/Mixer.java
+++ b/src/main/java/teamroots/embers/compat/groovyscript/Mixer.java
@@ -9,12 +9,13 @@ import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import groovyjarjarantlr4.v4.runtime.misc.Nullable;
 import net.minecraftforge.fluids.FluidStack;
+import teamroots.embers.Embers;
 import teamroots.embers.recipe.FluidMixingRecipe;
 import teamroots.embers.recipe.RecipeRegistry;
 
 import java.util.Arrays;
 
-@RegistryDescription
+@RegistryDescription(linkGenerator = Embers.MODID)
 public class Mixer extends VirtualizedRegistry<FluidMixingRecipe> {
     @RecipeBuilderDescription(example = {
             @Example(".fluidInput(fluid('water') * 100, fluid('lava') * 100).fluidOutput(fluid('dawnstone') * 100)")

--- a/src/main/java/teamroots/embers/compat/groovyscript/ReactionChamber.java
+++ b/src/main/java/teamroots/embers/compat/groovyscript/ReactionChamber.java
@@ -8,12 +8,13 @@ import com.cleanroommc.groovyscript.helper.SimpleObjectStream;
 import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import groovyjarjarantlr4.v4.runtime.misc.Nullable;
+import teamroots.embers.Embers;
 import teamroots.embers.recipe.FluidReactionRecipe;
 import teamroots.embers.recipe.RecipeRegistry;
 
 import java.awt.*;
 
-@RegistryDescription
+@RegistryDescription(linkGenerator = Embers.MODID)
 public class ReactionChamber extends VirtualizedRegistry<FluidReactionRecipe> {
     @RecipeBuilderDescription(example = @Example(".fluidInput(fluid('lava') * 10).fluidOutput(fluid('steam') * 50)"))
     public RecipeBuilder recipeBuilder() {

--- a/src/main/java/teamroots/embers/compat/groovyscript/Stamper.java
+++ b/src/main/java/teamroots/embers/compat/groovyscript/Stamper.java
@@ -10,12 +10,13 @@ import com.cleanroommc.groovyscript.helper.recipe.AbstractRecipeBuilder;
 import com.cleanroommc.groovyscript.registry.VirtualizedRegistry;
 import groovyjarjarantlr4.v4.runtime.misc.Nullable;
 import net.minecraft.item.crafting.Ingredient;
+import teamroots.embers.Embers;
 import teamroots.embers.recipe.ItemStampingRecipe;
 import teamroots.embers.recipe.RecipeRegistry;
 
 import java.util.Arrays;
 
-@RegistryDescription
+@RegistryDescription(linkGenerator = Embers.MODID)
 class Stamper extends VirtualizedRegistry<ItemStampingRecipe>{
      @RecipeBuilderDescription(example = {
             @Example(".stamp(item('minecraft:clay')).fluidInput(fluid('water') * 100).output(item('minecraft:brick'))"),

--- a/src/main/resources/assets/embers/lang/en_US.lang
+++ b/src/main/resources/assets/embers/lang/en_US.lang
@@ -1257,6 +1257,7 @@ groovyscript.wiki.embers.melter.description=Converts an input item into an outpu
 groovyscript.wiki.embers.stamper.title=Stamper
 groovyscript.wiki.embers.stamper.description=Converts an input fluid into an output item with a provided stamp in a Stamper.
 groovyscript.wiki.embers.stamper.stamp.required=Stamp Required
+groovyscript.wiki.embers.stamper.stamp.value=Sets the stamp used for the recipe
 groovyscript.wiki.embers.mixer.title=Mixer
 groovyscript.wiki.embers.mixer.description=Converts up to 3 input fluidstacks into an output fluidstack in a Mixer.
 groovyscript.wiki.embers.powerratio.value=0
@@ -1264,9 +1265,16 @@ groovyscript.wiki.embers.heat_coil.title=Heat Coil
 groovyscript.wiki.embers.heat_coil.description=Convert an input item into an output item in a Heat Coil.
 groovyscript.wiki.embers.alchemy.title=Alchemy
 groovyscript.wiki.embers.alchemy.description=Convert input items into an output item on a Exchange Tablet.
-groovyscript.wiki.embers.alchemy.getaspect=Returns the name of the aspect of an item.
+groovyscript.wiki.embers.alchemy.aspects.value=Sets what aspects are part of the recipe and their minimum/maximum value
+groovyscript.wiki.embers.alchemy.getaspect=Returns the name of the aspect of an item
+groovyscript.wiki.embers.alchemy.addaspect=Register the given Aspect with the given IIngredient
+groovyscript.wiki.embers.alchemy.removeaspect=Remove the given Aspect
+groovyscript.wiki.embers.alchemy.removebycenter=Removes all recipes with the center item matching the given IIngredient
 groovyscript.wiki.embers.reaction_chamber.title=Reaction Chamber
 groovyscript.wiki.embers.reaction_chamber.description=Converts an input fluidstack into an output fluidstack in a Reaction Chamber.
+groovyscript.wiki.embers.reaction_chamber.red.value=Sets the red value of the color
+groovyscript.wiki.embers.reaction_chamber.blue.value=Sets the blue value of the color
+groovyscript.wiki.embers.reaction_chamber.green.value=Sets the green value of the color
 
 # WIP - Stuff
 tile.seed_mithril.name=Mithril Crystal Seed


### PR DESCRIPTION
changes in this PR:
- in the `runConfig.json`, set `debug` to true. this enables additional logging information - in particular, it logs when lang keys are missing.
- in each RegistryDescription annotation, point to the Embers `linkGenerator`.
- add missing lang keys. it seems like all current lang keys are all lowercase, while the default GrS looks for whatever matches the field/method name. used the `description` field to enforce lowercase, but this may be unneeded.

